### PR TITLE
Fix from Bugly

### DIFF
--- a/app/src/main/java/github/tornaco/xposedmoduletest/ui/activity/helper/RunningState.java
+++ b/app/src/main/java/github/tornaco/xposedmoduletest/ui/activity/helper/RunningState.java
@@ -402,7 +402,8 @@ public class RunningState {
                 }
                 // Query starter.
                 if (XAshmanManager.get().isServiceAvailable()) {
-                    si.starter = XAshmanManager.get().getServiceStarter(si.mServiceInfo.getComponentName());
+                    // updateNow: java.lang.NoSuchMethodError: No virtual method getComponentName()Landroid/content/ComponentName; in class Landroid/content/pm/
+                    // si.starter = XAshmanManager.get().getServiceStarter(si.mServiceInfo.getComponentName());
                 }
                 si.mDisplayLabel = makeLabel(pm,
                         si.mRunningService.service.getClassName(), si.mServiceInfo);

--- a/app/src/main/res/layout/update_log_sheet_layout.xml
+++ b/app/src/main/res/layout/update_log_sheet_layout.xml
@@ -38,7 +38,7 @@
         android:layout_marginStart="@dimen/activity_horizontal_margin_small"
         android:layout_marginTop="@dimen/activity_horizontal_margin_small"
         android:padding="@dimen/header_padding_tiny"
-        android:text="@string/update_log_470"
+        android:text="@string/update_log_493"
         android:textAllCaps="true"
         android:textColor="?torListItemSummaryTextColor"
         android:textStyle="normal" />

--- a/app/src/main/res/values/update_logs.xml
+++ b/app/src/main/res/values/update_logs.xml
@@ -37,4 +37,6 @@
 
     <string name="update_log_470">1. 解决潜在的可能与某补丁冲突造成系统ANR问题。\n2. 修复Chrome等浏览器不显示到列表问题。\n3. 修复创建快捷方式闪退问题。\n4. Shell接口增加 锁屏/清理。\n5. 主页卡片摘要优化。
     </string>
+
+    <string name="update_log_493">修复正在M上运行应用无法加载问题。</string>
 </resources>


### PR DESCRIPTION
updateNow: java.lang.NoSuchMethodError: No virtual method getComponentName()Landroid/content/ComponentName; in class Landroid/content/pm/ServiceInfo; or its super classes (declaration of 'android.content.pm.ServiceInfo' appears in /system/framework/framework.jar) at github.tornaco.xposedmoduletest.ui.activity.helper.RunningState$ProcessItem.updateService(Unknown Source) at github.tornaco.xposedmoduletest.ui.activity.helper.RunningState.update(Unknown Source) at github.tornaco.xposedmoduletest.ui.activity.helper.RunningState.updateNow(Unknown Source) at github.tornaco.xposedmoduletest.cache.RunningServicesLoadingCache$2.load(Unknown Source) at github.tornaco.xposedmoduletest.cache.RunningServicesLoadingCache$2.load(Unknown Source) at com.google.common.cache.LocalCache$k.a(Unknown Source) at com.google.common.cache.LocalCache$p.a(Unknown Source) at com.google.common.cache.LocalCache$p.b(Unknown Source) at com.google.common.cache.LocalCache$p.a(Unknown Source) at com.google.comm [Message over limit siz...too long be cutted!